### PR TITLE
Resolve some pseudo parameters in env vars for local invocation

### DIFF
--- a/lib/plugins/aws/invokeLocal/index.js
+++ b/lib/plugins/aws/invokeLocal/index.js
@@ -22,6 +22,8 @@ const isStandalone = require('../../../utils/isStandaloneExecutable');
 const getEnsureArtifact = require('../../../utils/getEnsureArtifact');
 const resolveCfImportValue = require('../utils/resolveCfImportValue');
 const resolveCfRefValue = require('../utils/resolveCfRefValue');
+const getStackId = require('../utils/getStackId');
+const asyncStringReplace = require('../utils/asyncStringReplace');
 
 const cachePath = path.join(cachedir('serverless'), 'invokeLocal');
 
@@ -184,8 +186,32 @@ class AwsInvokeLocal {
 
       const configuredEnvVars = this.getConfiguredEnvVars();
 
+      const pseudoParameterRegex = /#{(AWS::[a-zA-Z]+)}/g;
+
       const promises = Object.entries(configuredEnvVars).map(async ([name, value]) => {
-        if (!_.isObject(value)) return;
+        if (!_.isObject(value)) {
+          configuredEnvVars[name] = await asyncStringReplace(
+            value,
+            pseudoParameterRegex,
+            async match => {
+              switch (match) {
+                case '#{AWS::Region}': {
+                  return this.provider.getRegion();
+                }
+                case '#{AWS::AccountId}': {
+                  return await this.provider.getAccountId();
+                }
+                case '#{AWS::StackName}':
+                  return this.provider.naming.getStackName();
+                case '#{AWS::StackId}':
+                  return await getStackId(this.provider);
+                default:
+                  return match;
+              }
+            }
+          );
+          return;
+        }
         try {
           if (value['Fn::ImportValue']) {
             configuredEnvVars[name] = await resolveCfImportValue(

--- a/lib/plugins/aws/utils/asyncStringReplace.js
+++ b/lib/plugins/aws/utils/asyncStringReplace.js
@@ -1,0 +1,21 @@
+'use strict';
+
+// Credit to https://dev.to/ycmjason/stringprototypereplace-asynchronously-28k9
+async function asyncStringReplace(str, regex, aReplacer) {
+  const substrings = [];
+  let match;
+  let i = 0;
+  while ((match = regex.exec(str)) !== null) {
+    // put non matching string
+    substrings.push(str.slice(i, match.index));
+    // call the async replacer function with the matched array spreaded
+    substrings.push(aReplacer(...match));
+    i = regex.lastIndex;
+  }
+  // put the rest of str
+  substrings.push(str.slice(i));
+  // wait for aReplacer calls to finish and join them back into string
+  return (await Promise.all(substrings)).join('');
+}
+
+module.exports = asyncStringReplace;

--- a/lib/plugins/aws/utils/getStackId.js
+++ b/lib/plugins/aws/utils/getStackId.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const ServerlessError = require('../../../classes/Error').ServerlessError;
+
+async function getStackId(provider, sdkParams = {}) {
+  const stackName = provider.naming.getStackName();
+  const { StackSummaries, NextToken } = await provider.request(
+    'CloudFormation',
+    'listStacks',
+    sdkParams
+  );
+  const stackSummary = StackSummaries.find(({ StackName }) => StackName === stackName);
+
+  if (stackSummary) {
+    return stackSummary.StackId;
+  }
+  if (NextToken) {
+    return getStackId(provider, { NextToken });
+  }
+
+  throw new ServerlessError(`Could not find the StackId of the ${stackName} stack.`);
+}
+
+module.exports = getStackId;

--- a/test/unit/lib/plugins/aws/utils/getStackId.test.js
+++ b/test/unit/lib/plugins/aws/utils/getStackId.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const expect = require('chai').expect;
+const BbPromise = require('bluebird');
+const getStackId = require('../../../../../../lib/plugins/aws/utils/getStackId');
+
+describe('#getStackId', () => {
+  it('should return the StackId of the current stack', async () => {
+    const provider = {
+      naming: {
+        getStackName: () => 'stack-name',
+      },
+      request: () =>
+        BbPromise.resolve({
+          StackSummaries: [
+            {
+              StackName: 'my-first-stack',
+              StackId: 'my-first-stack-id',
+            },
+            {
+              StackName: 'stack-name',
+              StackId: 'stack-id',
+            },
+          ],
+        }),
+    };
+    const result = await getStackId(provider);
+    expect(result).to.equal('stack-id');
+  });
+});


### PR DESCRIPTION
This feature will allow the following pseudo parameters to be resolved in env vars when locally invocating a function:

- `AWS::AccountId`
- `AWS::Region`
- `AWS::StackName`
- `AWS::StackId`

For example:

```yml
functions:
    environment:
      ACCOUNT_ID: '#{AWS::AccountId}'
      REGION_WITH_STACK_NAME: '#{AWS::Region}-#{AWS::StackName}'
```

Here, `ACCOUNT_ID` will be resolved to `123456789000` and `REGION_WITH_STACK_NAME` to `eu-west-1-my-stack-name`.